### PR TITLE
ci(github action): Docker integration tests

### DIFF
--- a/.github/workflows/ui-testing.yml
+++ b/.github/workflows/ui-testing.yml
@@ -1,0 +1,26 @@
+name: Manual Maven Workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
+      - name: Build all modules for integration test
+        run: mvn clean install
+
+      - name: Ui testing
+        run: |
+          cd tobago-example/tobago-example-demo
+          mvn verify -Pdocker -Pintegration-tests


### PR DESCRIPTION
* added a workflow to run ui tests for the tobago demo
* the workflow uses the "docker" and "integration-tests" as profile
* the workflow should be triggered manually, because the ui tests are currently unstable